### PR TITLE
Fix issues with JAXB xml depreciation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,15 +192,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>${jaxb-api.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${jaxb-api.version}</version>
-            <scope>runtime</scope>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.14.2</version>
         </dependency>
         <dependency>
             <groupId>com.sun.istack</groupId>

--- a/src/main/java/uk/gov/companieshouse/account/validator/model/felix/ixbrl/Data.java
+++ b/src/main/java/uk/gov/companieshouse/account/validator/model/felix/ixbrl/Data.java
@@ -1,11 +1,10 @@
 package uk.gov.companieshouse.account.validator.model.felix.ixbrl;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
-@XmlRootElement(name = "data")
+@JacksonXmlRootElement(localName = "data")
 public class Data {
 
     private String balanceSheetDate;
@@ -14,7 +13,7 @@ public class Data {
 
     private String companiesHouseRegisteredNumber;
 
-    @XmlElement(name = "BalanceSheetDate")
+    @JacksonXmlProperty(localName = "BalanceSheetDate")
     @JsonProperty("balance_sheet_date")
     public String getBalanceSheetDate() {
         return balanceSheetDate;
@@ -24,7 +23,7 @@ public class Data {
         this.balanceSheetDate = balanceSheetDate;
     }
 
-    @XmlElement(name = "AccountsType")
+    @JacksonXmlProperty(localName = "AccountsType")
     @JsonProperty("accounts_type")
     public String getAccountsType() {
         return accountsType;
@@ -34,7 +33,7 @@ public class Data {
         this.accountsType = accountsType;
     }
 
-    @XmlElement(name = "CompaniesHouseRegisteredNumber")
+    @JacksonXmlProperty(localName = "CompaniesHouseRegisteredNumber")
     @JsonProperty("companieshouse_registered_number")
     public String getCompaniesHouseRegisteredNumber() {
         return companiesHouseRegisteredNumber;

--- a/src/main/java/uk/gov/companieshouse/account/validator/model/felix/ixbrl/Errors.java
+++ b/src/main/java/uk/gov/companieshouse/account/validator/model/felix/ixbrl/Errors.java
@@ -1,14 +1,14 @@
 package uk.gov.companieshouse.account.validator.model.felix.ixbrl;
 
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
-@XmlRootElement(name = "errors")
+@JacksonXmlRootElement(localName = "errors")
 public class Errors {
 
     private String errorMessage;
 
-    @XmlElement(name = "ErrorMessage")
+    @JacksonXmlProperty(localName = "ErrorMessage")
     public String getErrorMessage() {
         return errorMessage;
     }

--- a/src/main/java/uk/gov/companieshouse/account/validator/model/felix/ixbrl/Results.java
+++ b/src/main/java/uk/gov/companieshouse/account/validator/model/felix/ixbrl/Results.java
@@ -1,14 +1,13 @@
 package uk.gov.companieshouse.account.validator.model.felix.ixbrl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
-@XmlRootElement(name = "results")
+@JacksonXmlRootElement(localName = "results")
 public class Results {
 
     private List<Errors> errors;
@@ -17,8 +16,8 @@ public class Results {
 
     private Data data;
 
-    @XmlElement
-    @JsonProperty("errorMessages")
+    @JacksonXmlElementWrapper(localName = "errorMessages")
+    @JacksonXmlProperty(localName = "error")
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public List<Errors> getErrors() {
         return errors;
@@ -28,7 +27,7 @@ public class Results {
         this.errors = errors;
     }
 
-    @XmlElement
+    @JacksonXmlProperty(localName = "data")
     public Data getData() {
         return data;
     }
@@ -37,7 +36,7 @@ public class Results {
         this.data = data;
     }
 
-    @XmlAttribute
+    @JacksonXmlProperty(isAttribute = true, localName = "validationStatus")
     public String getValidationStatus() {
         return validationStatus;
     }


### PR DESCRIPTION
JAXB has been depreciated in java 11. This PR changes the deserialisation to use jackson XML instead.