### PR TITLE
Update sdk version to correctly encode package type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>private-api-sdk-java</artifactId>
-            <version>2.0.390</version>
+            <version>2.0.394</version>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>

--- a/src/main/java/uk/gov/companieshouse/account/validator/service/FelixAccountValidator.java
+++ b/src/main/java/uk/gov/companieshouse/account/validator/service/FelixAccountValidator.java
@@ -12,7 +12,6 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.felixvalidator.PrivateFelixValidatorResourceHandler;
 import uk.gov.companieshouse.api.model.felixvalidator.AsyncValidationRequestApi;
-import uk.gov.companieshouse.api.model.felixvalidator.PackageTypeApi;
 import uk.gov.companieshouse.api.model.filetransfer.FileDetailsApi;
 import uk.gov.companieshouse.logging.Logger;
 


### PR DESCRIPTION
Update sdk version to include changes from the following pr https://github.com/companieshouse/private-api-sdk-java/pull/609.
This will ensure package type enums are correctly encoded into JSON.