### PR TITLE
update autoscaling and scheduling

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -4,3 +4,7 @@ aws_profile = "development-eu-west-2"
 # service configs
 use_set_environment_files = true
 
+# Scheduled scaling of tasks
+service_autoscale_enabled  = true
+service_scaledown_schedule = "55 19 * * ? *"
+service_scaleup_schedule   = "5 6 * * ? *"

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -77,7 +77,7 @@ variable "service_autoscale_enabled" {
 variable "service_autoscale_target_value_cpu" {
   type        = number
   description = "Target CPU percentage for the ECS Service to autoscale on"
-  default     = 50 # 100 disables autoscaling using CPU as a metric
+  default     = 80 # 100 disables autoscaling using CPU as a metric
 }
 variable "service_scaledown_schedule" {
   type        = string


### PR DESCRIPTION
Add service schedule for cidev, already present in staging.
No need having them running 24/7
Also have modified the autosclaing when cpu has reached 80% instead of 50% 